### PR TITLE
Add move history tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ uvicorn app:app --reload --host 0.0.0.0 --port 8000
 
 terminal 2:
 ngrok http 8000
+
+The server keeps track of all recognised moves.  Fetch the current move
+history (in SAN) via:
+
+```
+GET /history
+```

--- a/app.py
+++ b/app.py
@@ -62,6 +62,15 @@ async def calibrate(image_b64: str = Body(..., media_type="text/plain")):
     return {"ok": True}
 
 # ---------------------------------------------------------------------------
+# HTTP endpoint – current move history
+# ---------------------------------------------------------------------------
+
+@app.get("/history")
+async def get_history():
+    """Return the list of moves seen so far in SAN."""
+    return {"moves": tracker.get_history()}
+
+# ---------------------------------------------------------------------------
 # WebSocket – streaming frames → moves / FEN
 # ---------------------------------------------------------------------------
 
@@ -86,7 +95,7 @@ async def ws_endpoint(ws: WebSocket):
             move, fen = tracker.update(occ)
 
             if move:
-                await ws.send_json({"move": move, "fen": fen})
+                await ws.send_json({"move": move, "fen": fen, "history": tracker.get_history()})
             else:
                 await ws.send_json({"noop": True})
     except WebSocketDisconnect:

--- a/static/index.html
+++ b/static/index.html
@@ -14,6 +14,7 @@
     #board{width:400px;margin-top:12px}
     #status{margin-top:8px;color:#444}
     #cam  {display:block}               /* set to block if you want a preview */
+    #history{white-space:pre-wrap;margin-top:8px}
   </style>
 </head>
 
@@ -22,11 +23,13 @@
   <video id="cam" autoplay muted playsinline></video>
   <div id="board"></div>
   <div id="status">Waiting for camera …</div>
+  <pre id="history"></pre>
 
   <script>
   /* -------------------- helpers -------------------- */
   const statusEl = document.getElementById('status');
   const videoEl  = document.getElementById('cam');
+  const historyEl = document.getElementById('history');
 
   function wsURL () {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -110,6 +113,7 @@
       ws.onmessage = ({data}) => {
         const msg = JSON.parse(data);
         if (msg.move) board.move(msg.move);        // animate move
+        if (msg.history) historyEl.textContent = msg.history.join(' ');
         if (msg.err)  statusEl.textContent = msg.err;
       };
 

--- a/tracker.py
+++ b/tracker.py
@@ -39,6 +39,7 @@ class SquareTracker:
     def __init__(self, fen: str | None = None):
         self.board: chess.Board = chess.Board(fen) if fen else chess.Board()
         self.prev: np.ndarray = _board_to_occ(self.board)
+        self.history: list[str] = []
 
     # ---------------------------------------------------------------------
     # Public helpers
@@ -47,6 +48,11 @@ class SquareTracker:
         """Set a fresh game state and sync the occupancy baseline."""
         self.board.set_fen(fen) if fen else self.board.reset()
         self.prev = _board_to_occ(self.board)
+        self.history.clear()
+
+    def get_history(self) -> list[str]:
+        """Return the SAN history of all recognised moves."""
+        return self.history.copy()
 
     # ---------------------------------------------------------------------
     # Core – consume a new 8 × 8 occupancy matrix
@@ -89,8 +95,9 @@ class SquareTracker:
             return None, None
 
         # Push the single matching move.
-        san_before = self.board.san(candidate)  # for UI if needed
+        san_before = self.board.san(candidate)  # SAN before pushing
         self.board.push(candidate)
+        self.history.append(san_before)
         self.prev = new_occ.copy()
         return candidate.uci(), self.board.fen()
 


### PR DESCRIPTION
## Summary
- keep SAN move history in `SquareTracker`
- expose `/history` endpoint and include history in websocket responses
- display move history in the frontend
- document new endpoint in the README

## Testing
- `python -m py_compile app.py tracker.py vision.py`


------
https://chatgpt.com/codex/tasks/task_e_6866c12196d8832db2e7a45ad4f7eb36