### PR TITLE
Add CNN-based occupancy detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ uvicorn app:app --reload --host 0.0.0.0 --port 8000
 terminal 2:
 ngrok http 8000
 
+Open `http://localhost:8000` in a browser. After granting camera access press
+the **Calibrate board** button once with an empty board visible. Set up the
+pieces and press the button again to start tracking.
+
 The server keeps track of all recognised moves.  Fetch the current move
 history (in SAN) via:
 

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import base64
 import cv2 as cv
 import numpy as np
 
-from vision import find_board, warp_board, occupancy_hsv, draw_board_overlay
+from vision import find_board, warp_board, occupancy_cnn, draw_board_overlay
 from tracker import SquareTracker
 
 from fastapi.staticfiles import StaticFiles
@@ -91,7 +91,7 @@ async def ws_endpoint(ws: WebSocket):
                 continue
 
             board_img, _ = warp_board(frame, _corners)
-            occ = occupancy_hsv(board_img)
+            occ = occupancy_cnn(board_img)
             move, fen = tracker.update(occ)
 
             if move:

--- a/requirement.txt
+++ b/requirement.txt
@@ -3,4 +3,5 @@ uvicorn[standard]
 opencv-python
 numpy
 python-chess
-tensorflow==2.16.1        # or torch / tflite
+torch
+torchvision

--- a/static/index.html
+++ b/static/index.html
@@ -21,6 +21,7 @@
 <body>
   <h2>Phone Chess Tracker (PoC)</h2>
   <video id="cam" autoplay muted playsinline></video>
+  <button id="calib">Calibrate board</button>
   <div id="board"></div>
   <div id="status">Waiting for camera …</div>
   <pre id="history"></pre>
@@ -30,6 +31,7 @@
   const statusEl = document.getElementById('status');
   const videoEl  = document.getElementById('cam');
   const historyEl = document.getElementById('history');
+  const calibBtn  = document.getElementById('calib');
 
   function wsURL () {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -78,7 +80,54 @@
   });
 
   /* -------------------- main flow ------------------- */
-  let ws, stream, frameTimer;
+  let ws, stream, track, frameTimer, step = 0;
+
+  async function startWS () {
+    ws = new WebSocket(wsURL());
+    ws.onopen    = () => statusEl.textContent = 'Connected – tracking moves.';
+    ws.onclose   = () => statusEl.textContent = 'WebSocket closed';
+    ws.onerror   = e  => console.error('WS error', e);
+    ws.onmessage = ({data}) => {
+      const msg = JSON.parse(data);
+      if (msg.move) board.move(msg.move);        // animate move
+      if (msg.history) historyEl.textContent = msg.history.join(' ');
+      if (msg.err)  statusEl.textContent = msg.err;
+    };
+
+    frameTimer = setInterval(async () => {
+      if (ws.readyState !== 1) return;           // skip unless OPEN
+      try {
+        const fr   = await grabFrame(track);
+        const blob = await frameToBlob(fr);
+        const b64  = await blobToB64(blob);
+        ws.send(b64);
+      } catch (e) {
+        console.error('frame error', e);
+      }
+    }, 1000);                                    // 1 FPS (adjust to taste)
+  }
+
+  async function calibrate () {
+    const fr   = await grabFrame(track);
+    const blob = await frameToBlob(fr);
+    const b64  = await blobToB64(blob);
+    if (step === 0) {
+      statusEl.textContent = 'Calibrating…';
+      const res = await fetch('/calibrate', {method:'POST', body:b64});
+      if (!res.ok) {
+        statusEl.textContent = 'Calibration failed – show the whole board & retry';
+        return;
+      }
+      step = 1;
+      statusEl.textContent = 'Corners found. Set up the board and press again.';
+      calibBtn.textContent = 'Start tracking';
+    } else {
+      calibBtn.disabled = true;
+      startWS();
+    }
+  }
+
+  calibBtn.addEventListener('click', calibrate);
 
   (async function init () {
     try {
@@ -89,46 +138,11 @@
       await new Promise(res => {
         if (videoEl.readyState >= 2) return res();        // HAVE_CURRENT_DATA
         videoEl.onloadeddata = res;                       // fires when first frame arrives
-        });
+      });
 
-      const track = stream.getVideoTracks()[0];
-
-      /* calibration ------------------------------------------------------ */
-      statusEl.textContent = 'Calibrating board …';
-      const firstFrame = await grabFrame(track);
-      const firstBlob  = await frameToBlob(firstFrame);
-      const firstB64   = await blobToB64(firstBlob);
-
-      const res = await fetch('/calibrate', {method:'POST', body:firstB64});
-      if (!res.ok) {
-        statusEl.textContent = 'Calibration failed – show the whole board & retry';
-        return;
-      }
-
-      /* websocket -------------------------------------------------------- */
-      ws = new WebSocket(wsURL());
-      ws.onopen    = () => statusEl.textContent = 'Connected – tracking moves.';
-      ws.onclose   = () => statusEl.textContent = 'WebSocket closed';
-      ws.onerror   = e  => console.error('WS error', e);
-      ws.onmessage = ({data}) => {
-        const msg = JSON.parse(data);
-        if (msg.move) board.move(msg.move);        // animate move
-        if (msg.history) historyEl.textContent = msg.history.join(' ');
-        if (msg.err)  statusEl.textContent = msg.err;
-      };
-
-      /* loop ------------------------------------------------------------- */
-      frameTimer = setInterval(async () => {
-        if (ws.readyState !== 1) return;           // skip unless OPEN
-        try {
-          const fr   = await grabFrame(track);
-          const blob = await frameToBlob(fr);
-          const b64  = await blobToB64(blob);
-          ws.send(b64);
-        } catch (e) {
-          console.error('frame error', e);
-        }
-      }, 1000);                                    // 1 FPS (adjust to taste)
+      track = stream.getVideoTracks()[0];
+      statusEl.textContent = 'Point camera at empty board and press \"Calibrate board\"';
+      calibBtn.disabled = false;
     } catch (err) {
       console.error(err);
       statusEl.textContent = 'Camera access failed: ' + err.message;

--- a/vision.py
+++ b/vision.py
@@ -2,6 +2,14 @@ import cv2 as cv
 import numpy as np
 from typing import Tuple, Optional
 
+from chess_cnn.opencv_chessboard_finder import (
+    detect_corners,
+    outer_corners_from_inner,
+)
+import torch
+import torch.nn as nn
+from torchvision import models, transforms
+
 """vision.py – camera‑side utilities
 -------------------------------------
 •  Calibrate the chessboard once per session (detect 4 corners)
@@ -16,7 +24,7 @@ classifier trained on 64 × 64 crops – the public API remains identical.
 # ---------------------------------------------------------------------------
 # Constants & tunables
 # ---------------------------------------------------------------------------
-CALIB_SIZE = 800                 # output board width/height in px
+CALIB_SIZE = 800                 # output board width/height in px
 
 # HSV thresholds – tweak for your lighting & pieces; mask ∈ [0, 255]
 WHITE_LOWER = (0, 0, 170)
@@ -26,6 +34,9 @@ BLACK_UPPER = (180, 255, 70)
 
 # Morphology kernel for noise suppression
 _KERNEL = cv.getStructuringElement(cv.MORPH_ELLIPSE, (3, 3))
+
+# Lazy loaded CNN model
+_CNN_MODEL = None
 
 
 # ---------------------------------------------------------------------------
@@ -38,29 +49,13 @@ def find_board(frame: np.ndarray) -> Optional[np.ndarray]:
     The corners are **ordered TL, TR, BR, BL** (clockwise, starting top‑left)
     and expressed in the *input‑frame* coordinate space.
     """
-    gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)
+    try:
+        inner = detect_corners(frame, rows=7, cols=7)
+    except Exception:
+        return None
 
-    # 1. Edge map
-    edges = cv.Canny(gray, 50, 150, apertureSize=3)
-
-    # 2. Probabilistic Hough – find candidate long lines (board border)
-    lines = cv.HoughLinesP(edges, 1, np.pi / 180, threshold=150,
-                           minLineLength=0.5 * min(frame.shape[:2]),
-                           maxLineGap=20)
-    if lines is None or len(lines) < 4:
-        return None  # not enough structure
-
-    # 3. Gather all endpoints; fit a minimum‑area rectangle around them
-    pts = np.concatenate([[l[0][:2], l[0][2:]] for l in lines])
-    rect = cv.minAreaRect(pts)          # ((cx, cy), (w, h), angle)
-    box  = cv.boxPoints(rect)           # 4 × 2 float32
-
-    # 4. Ensure top‑left is first, then clockwise order
-    box = sorted(box, key=lambda p: (p[1], p[0]))        # sort by y, then x
-    tl, tr = sorted(box[:2], key=lambda p: p[0])          # leftmost of top two
-    bl, br = sorted(box[2:], key=lambda p: p[0])
-    ordered = np.array([tl, tr, br, bl], dtype=np.float32)
-    return ordered
+    corners = outer_corners_from_inner(inner, rows=7, cols=7)
+    return corners.astype(np.float32)
 
 
 def warp_board(frame: np.ndarray, corners: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
@@ -77,11 +72,10 @@ def warp_board(frame: np.ndarray, corners: np.ndarray) -> Tuple[np.ndarray, np.n
         *img* – warped board (CALIB_SIZE × CALIB_SIZE × 3, BGR)
         *M*   – 3 × 3 homography matrix (frame → board)
     """
-    dst = np.array([[0, 0], [CALIB_SIZE, 0],
-                    [CALIB_SIZE, CALIB_SIZE], [0, CALIB_SIZE]], dtype=np.float32)
-    M = cv.getPerspectiveTransform(corners, dst)
-    board_img = cv.warpPerspective(frame, M, (CALIB_SIZE, CALIB_SIZE))
-    return board_img, M
+    dst = np.array([[0, 0], [CALIB_SIZE, 0], [CALIB_SIZE, CALIB_SIZE], [0, CALIB_SIZE]], dtype=np.float32)
+    H, _ = cv.findHomography(corners.astype(np.float32), dst)
+    board_img = cv.warpPerspective(frame, H, (CALIB_SIZE, CALIB_SIZE))
+    return board_img, H
 
 
 # ---------------------------------------------------------------------------
@@ -113,6 +107,52 @@ def occupancy_hsv(board_img: np.ndarray) -> np.ndarray:
                 occ[r, c] = 1
             elif roi_b.mean() > 30:
                 occ[r, c] = 2
+    return occ
+
+
+def _load_cnn_model(device=None) -> nn.Module:
+    """Lazy-load the CNN piece classifier."""
+    global _CNN_MODEL
+    if '_CNN_MODEL' in globals() and _CNN_MODEL is not None:
+        return _CNN_MODEL
+
+    device = device or ('cuda' if torch.cuda.is_available() else 'cpu')
+
+    def build_model(num_classes: int = 3) -> nn.Module:
+        m = models.mobilenet_v2(weights=models.MobileNet_V2_Weights.IMAGENET1K_V1)
+        m.classifier[1] = nn.Linear(m.classifier[1].in_features, num_classes)
+        return m
+
+    model = build_model()
+    state = torch.load('assets/model.pt', map_location=device)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
+    _CNN_MODEL = model
+    return model
+
+
+_TRANSFORM = transforms.Compose([
+    transforms.ToTensor(),
+    transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+])
+
+
+def occupancy_cnn(board_img: np.ndarray) -> np.ndarray:
+    """Return occupancy matrix using the trained CNN classifier."""
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = _load_cnn_model(device)
+    sq = CALIB_SIZE // 8
+    occ = np.zeros((8, 8), np.int8)
+    with torch.no_grad():
+        for r in range(8):
+            for c in range(8):
+                crop = board_img[r * sq:(r + 1) * sq, c * sq:(c + 1) * sq]
+                crop = cv.resize(crop, (64, 64))
+                crop = cv.cvtColor(crop, cv.COLOR_BGR2RGB)
+                inp = _TRANSFORM(crop).unsqueeze(0).to(device)
+                pred = model(inp).argmax(1).item()
+                occ[r, c] = pred
     return occ
 
 


### PR DESCRIPTION
## Summary
- use chessboard finder from `chess_cnn` for calibration
- load trained MobileNetV2 CNN for occupancy detection
- switch WebSocket loop to use CNN predictions
- update requirements to install torch
- add calibration button to web UI for two-step setup
- avoid sending /calibrate twice on the second button press

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881f1c458b0832da7b42ddbb53256f8