### PR TITLE
Add basic logging to websocket endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,9 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Body
 import base64
 import cv2 as cv
 import numpy as np
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 from vision import find_board, warp_board, occupancy_cnn, draw_board_overlay
 from tracker import SquareTracker
@@ -93,6 +96,11 @@ async def ws_endpoint(ws: WebSocket):
             board_img, _ = warp_board(frame, _corners)
             occ = occupancy_cnn(board_img)
             move, fen = tracker.update(occ)
+
+            if move:
+                logging.info("Move detected: %s -> %s", move, fen)
+            else:
+                logging.debug("No move detected for frame")
 
             if move:
                 await ws.send_json({"move": move, "fen": fen, "history": tracker.get_history()})


### PR DESCRIPTION
## Summary
- add logging configuration to `app.py`
- log moves and missing moves in websocket endpoint

## Testing
- `python -m py_compile app.py vision.py tracker.py`

------
https://chatgpt.com/codex/tasks/task_e_68876a1b45cc832d9f3d49409f4e7eb6